### PR TITLE
Fix "associated type `Data` not found" error

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -139,8 +139,8 @@ impl<D: PxAssetData> Default for LoadingAssets<D> {
 pub struct PxAssets<'w, 's, A: PxAssetTrait> {
     _query: Query<'w, 's, ()>,
     asset_server: Res<'w, AssetServer>,
-    assets: ResMut<'w, Assets<PxAsset<A::Data>>>,
-    loading_resource: ResMut<'w, LoadingAssets<A::Data>>,
+    assets: ResMut<'w, Assets<PxAsset<<A as PxAssetTrait>::Data>>>,
+    loading_resource: ResMut<'w, LoadingAssets<<A as PxAssetTrait>::Data>>,
 }
 
 impl<'w, 's, A: PxAssetTrait> PxAssets<'w, 's, A> {


### PR DESCRIPTION
## Overview

When I use the latest code from `main` or from version `0.2` of the crate, I get the following error during compilation:  "associated type `Data` not found" (see screenshot below). After some trial and error, I found that the compiler wanted me to explicitly cast the generic `A` type to `PxAssetTrait`, so that is what this PR does. This seems to fix the issue, though it does seem a bit odd that the compiler requires this explicit casting.

## System

OS: Windows 11
Rust: Stable 1.68.2

## Screenshot
![Screenshot 2023-04-14 002052](https://user-images.githubusercontent.com/3893845/231948389-206366cd-785b-48b9-b2cf-4925c78713d7.png)
