### PR TITLE
Fix rendering for WASM target

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -27,7 +27,7 @@ pub(crate) fn cursor_plugin(app: &mut App) {
                 .in_set(PxSet::UpdateCursorPosition),
         )
         .add_system(change_cursor.before(PxSet::DrawCursor))
-        .add_system(draw_cursor.in_set(PxSet::DrawCursor));
+        .add_system(draw_cursor.in_set(PxSet::DrawCursor).in_set(PxSet::Loaded));
 }
 
 /// Resource that defines whether to use an in-game cursor

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -40,7 +40,7 @@ pub(crate) fn screen_plugin<L: PxLayer>(size: UVec2) -> impl FnOnce(&mut App) {
             .add_systems(
                 (apply_system_buffers, draw_screen::<L>)
                     .chain()
-                    .in_set(PxSet::Draw),
+                    .in_set(PxSet::Draw)
                     .in_set(PxSet::Loaded),
             )
             .add_systems(

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -41,6 +41,7 @@ pub(crate) fn screen_plugin<L: PxLayer>(size: UVec2) -> impl FnOnce(&mut App) {
                 (apply_system_buffers, draw_screen::<L>)
                     .chain()
                     .in_set(PxSet::Draw),
+                    .in_set(PxSet::Loaded),
             )
             .add_systems(
                 (
@@ -48,7 +49,7 @@ pub(crate) fn screen_plugin<L: PxLayer>(size: UVec2) -> impl FnOnce(&mut App) {
                     init_screen(size).run_if(resource_added::<Palette>()),
                     resize_screen.in_set(PxSet::Loaded),
                     clear_screen.before(PxSet::Draw).in_set(PxSet::Loaded),
-                    update_screen_palette,
+                    update_screen_palette.in_set(PxSet::Loaded),
                 )
                     .in_base_set(CoreSet::PostUpdate),
             );
@@ -138,6 +139,8 @@ fn init_screen(
         });
 
         let (entity, window) = windows.single();
+        let calculated_screen_scale =
+            screen_scale(size, Vec2::new(window.width(), window.height())).extend(1.);
 
         commands.spawn((
             MaterialMesh2dBundle {
@@ -146,9 +149,9 @@ fn init_screen(
                     image,
                     palette: screen_palette,
                 }),
-                transform: Transform::from_scale(
-                    screen_scale(size, Vec2::new(window.width(), window.height())).extend(1.),
-                ),
+                transform: Transform::from_scale(calculated_screen_scale),
+                // Ensure transform matches global_transform to ensure correct rendering for WASM
+                global_transform: GlobalTransform::from_scale(calculated_screen_scale),
                 ..default()
             },
             ScreenMarker,


### PR DESCRIPTION
## Overview

This PR updates the screen/cursor plugin logic to ensure correct rendering for the WASM target. It does this by making sure screen drawing functionality only starts after the `Screen` and `Palette` resources have been loaded and by matching the global and local transforms of the Screen `MaterialMesh2dBundle` component (will show blank screen otherwise).

## Changes

- Added `.in_set(PxSet::Loaded)` to the `(apply_system_buffers, draw_screen)`, `update_screen_palette` and `draw_cursor` systems
- Added the `calculated_screen_scale` variable to both the `transform` and `global_transform` of the `MaterialMesh2dBundle` component for the `Screen` name bundle

Closes #2.

> NOTE: This PR depends on #1 as well

## Screenshot

![Screenshot 2023-04-14 225835](https://user-images.githubusercontent.com/3893845/232181839-272e4b64-dbb6-46f5-89df-96ca474ece2e.png)
