### PR TITLE
Add PxFlip for sprite and tile.

### DIFF
--- a/examples/sprite_flip.rs
+++ b/examples/sprite_flip.rs
@@ -1,0 +1,50 @@
+// In this program, a sprite can be flipped with X and Y keys.
+
+use bevy::prelude::*;
+use seldom_pixel::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    resolution: Vec2::splat(512.).into(),
+                    ..default()
+                }),
+                ..default()
+            }),
+            PxPlugin::<Layer>::new(UVec2::splat(16), "palette/palette_1.palette.png"),
+        ))
+        .insert_resource(ClearColor(Color::BLACK))
+        .add_systems(Startup, init)
+        .add_systems(Update, on_key)
+        .run();
+}
+
+fn init(assets: Res<AssetServer>, mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    // Spawn a sprite
+    commands.spawn((
+        PxSprite(assets.load("sprite/mage.px_sprite.png")),
+        PxPosition(IVec2::splat(8)),
+        PxFlip::default(),
+    ));
+}
+
+fn on_key(input: Res<ButtonInput<KeyCode>>, mut query: Query<&mut PxFlip>) {
+    if input.just_pressed(KeyCode::KeyX) {
+        for mut flip in &mut query {
+            flip.x = !flip.x;
+        }
+    }
+
+    if input.just_pressed(KeyCode::KeyY) {
+        for mut flip in &mut query {
+            flip.y = !flip.y;
+        }
+    }
+}
+
+#[px_layer]
+struct Layer;

--- a/examples/tilemap_flip.rs
+++ b/examples/tilemap_flip.rs
@@ -1,0 +1,63 @@
+// In this program, a tilemap can be flipped with x and y keys.
+
+use bevy::prelude::*;
+use rand::{thread_rng, Rng};
+use seldom_pixel::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    resolution: Vec2::splat(512.).into(),
+                    ..default()
+                }),
+                ..default()
+            }),
+            PxPlugin::<Layer>::new(UVec2::splat(16), "palette/palette_1.palette.png"),
+        ))
+        .insert_resource(ClearColor(Color::BLACK))
+        .add_systems(Startup, init)
+        .add_systems(Update, on_key)
+        .run();
+}
+
+fn init(assets: Res<AssetServer>, mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    let mut tiles = PxTiles::new(UVec2::splat(4));
+    let mut rng = thread_rng();
+
+    for x in 0..4 {
+        for y in 0..4 {
+            tiles.set(
+                Some(commands.spawn((PxTile::from(rng.gen_range(0..4)),
+                                     PxFlip::default())).id()),
+                UVec2::new(x, y),
+            );
+        }
+    }
+
+    // Spawn the map
+    commands.spawn(PxMap {
+        tiles,
+        tileset: assets.load("tileset/tileset.px_tileset.png"),
+    });
+}
+
+fn on_key(input: Res<ButtonInput<KeyCode>>, mut query: Query<&mut PxFlip>) {
+    if input.just_pressed(KeyCode::KeyX) {
+        for mut flip in &mut query {
+            flip.x = !flip.x;
+        }
+    }
+
+    if input.just_pressed(KeyCode::KeyY) {
+        for mut flip in &mut query {
+            flip.y = !flip.y;
+        }
+    }
+}
+
+#[px_layer]
+struct Layer;

--- a/src/map.rs
+++ b/src/map.rs
@@ -301,13 +301,13 @@ fn extract_maps<L: PxLayer>(
     }
 }
 
-pub(crate) type TileComponents = (&'static PxTile, Option<&'static PxFilter>);
+pub(crate) type TileComponents = (&'static PxTile, Option<&'static PxFilter>, Option<&'static PxFlip>);
 
 fn extract_tiles(
     tiles: Extract<Query<(TileComponents, &InheritedVisibility, RenderEntity)>>,
     mut cmd: Commands,
 ) {
-    for ((tile, filter), visibility, entity) in &tiles {
+    for ((tile, filter, flip), visibility, entity) in &tiles {
         if !visibility.get() {
             continue;
         }
@@ -319,6 +319,12 @@ fn extract_tiles(
             entity.insert(filter.clone());
         } else {
             entity.remove::<PxFilter>();
+        }
+
+        if let Some(flip) = flip {
+            entity.insert(flip.clone());
+        } else {
+            entity.remove::<PxFlip>();
         }
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,7 +25,7 @@ pub use crate::{
     math::{Diagonal, Orthogonal},
     position::{PxAnchor, PxLayer, PxPosition, PxSubPosition, PxVelocity},
     screen::ScreenSize,
-    sprite::{PxSprite, PxSpriteAsset},
+    sprite::{PxSprite, PxSpriteAsset, PxFlip},
     text::{PxText, PxTypeface},
     ui::PxRect,
     PxPlugin,

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -394,17 +394,17 @@ impl<L: PxLayer> ViewNode for PxRenderNode<L> {
         //     }
         // }
 
-        for (sprite, position, anchor, layer, canvas, animation, filter) in
+        for (sprite, position, anchor, layer, canvas, animation, filter, flip) in
             self.sprites.iter_manual(world)
         {
             if let Some((_, sprites, _, _, _, _, _)) = layer_contents.get_mut(layer) {
-                sprites.push((sprite, position, anchor, canvas, animation, filter));
+                sprites.push((sprite, position, anchor, canvas, animation, filter, flip));
             } else {
                 layer_contents.insert(
                     layer.clone(),
                     (
                         default(),
-                        vec![(sprite, position, anchor, canvas, animation, filter)],
+                        vec![(sprite, position, anchor, canvas, animation, filter, flip)],
                         default(),
                         default(),
                         default(),
@@ -578,7 +578,7 @@ impl<L: PxLayer> ViewNode for PxRenderNode<L> {
                             continue;
                         };
 
-                        let Ok((&PxTile { texture }, tile_filter)) =
+                        let Ok((&PxTile { texture }, tile_filter, tile_flip)) =
                             self.tiles.get_manual(world, tile)
                         else {
                             continue;
@@ -591,7 +591,7 @@ impl<L: PxLayer> ViewNode for PxRenderNode<L> {
 
                         draw_spatial(
                             tile,
-                            (),
+                            tile_flip.cloned().unwrap_or_default(),
                             &mut layer_image,
                             (**position + pos.as_ivec2() * tileset.tile_size().as_ivec2()).into(),
                             PxAnchor::BottomLeft,
@@ -748,14 +748,14 @@ impl<L: PxLayer> ViewNode for PxRenderNode<L> {
             //     );
             // }
 
-            for (sprite, position, anchor, canvas, animation, filter) in sprites {
+            for (sprite, position, anchor, canvas, animation, filter, flip) in sprites {
                 let Some(sprite) = sprite_assets.get(&**sprite) else {
                     continue;
                 };
 
                 draw_spatial(
                     sprite,
-                    (),
+                    flip.cloned().unwrap_or_default(),
                     &mut layer_image,
                     *position,
                     *anchor,
@@ -896,7 +896,7 @@ impl<L: PxLayer> ViewNode for PxRenderNode<L> {
 
                             draw_spatial(
                                 character,
-                                (),
+                                PxFlip::default(),
                                 &mut text_image,
                                 IVec2::new(character_x as i32, line_y as i32).into(),
                                 PxAnchor::BottomLeft,


### PR DESCRIPTION
Added sprite_flip.rs and tilemap_flip.rs in examples as well. The sprite_flip appears to work well. The tilemap_flip seems to work for x-axis flip but not y-axis.


![sprite flip for x-axis](https://github.com/user-attachments/assets/3e49f4f1-249b-470a-b954-b8ad284f26aa)

I did not add any flip for text because I wasn't even sure what it might mean and it looked complicated.